### PR TITLE
Update app group ID in share extension

### DIFF
--- a/NexusShareExtension/SharedFileManager.swift
+++ b/NexusShareExtension/SharedFileManager.swift
@@ -8,7 +8,10 @@
 import Foundation
 
 struct SharedFileManager {
-    static let appGroupID = "group.com.yourcompany.NexusFileApp"
+    /// The identifier for the shared app group used between the main app and
+    /// the share extension. This must match the value in both the app and
+    /// extension entitlements.
+    static let appGroupID = "group.com.leon.NexusFileApp"
 
     static var containerURL: URL {
         FileManager.default


### PR DESCRIPTION
## Summary
- update `SharedFileManager` to use the shared app group identifier
- confirm both entitlements already reference the same group

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6845ed7f7e1c8331be77a2da44d67766