### PR TITLE
Implement subfolder creation in share extension

### DIFF
--- a/NexusShareExtension/ShareContentView.swift
+++ b/NexusShareExtension/ShareContentView.swift
@@ -13,6 +13,8 @@ struct ShareContentView: View {
 
     @State private var chosenFolder = ""
     @State private var fileName = ""
+    @State private var showingNewFolder = false
+    @State private var refreshID = UUID()
 
     var body: some View {
         NavigationStack {
@@ -20,10 +22,11 @@ struct ShareContentView: View {
                 chosenFolder = folder
                 fileName = sharedURL.lastPathComponent
             }
+            .id(refreshID)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Maak Submap") {
-                        // TODO: present a sheet to create a new subfolder here
+                        showingNewFolder = true
                     }
                     .disabled(chosenFolder.isEmpty)
                 }
@@ -47,6 +50,42 @@ struct ShareContentView: View {
                 }
                 .navigationTitle("Baskanselleer")
             }
+        }
+        .sheet(isPresented: $showingNewFolder) {
+            NewSubfolderSheet(title: "Nuwe Submap", placeholder: "Naam") { name in
+                try? SharedFileManager.createSubfolder(named: name, in: chosenFolder)
+                refreshID = UUID()
+            }
+        }
+    }
+}
+
+private struct NewSubfolderSheet: View {
+    let title: String
+    let placeholder: String
+    var onCreate: (String) -> Void
+
+    @Environment(\.presentationMode) private var presentationMode
+    @State private var name = ""
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text(title)) {
+                    TextField(placeholder, text: $name)
+                }
+            }
+            .navigationTitle(title)
+            .navigationBarItems(
+                leading: Button("Cancel") {
+                    presentationMode.wrappedValue.dismiss()
+                },
+                trailing: Button("Create") {
+                    onCreate(name.trimmingCharacters(in: .whitespaces))
+                    presentationMode.wrappedValue.dismiss()
+                }
+                .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
+            )
         }
     }
 }

--- a/NexusShareExtension/SharedFileManager.swift
+++ b/NexusShareExtension/SharedFileManager.swift
@@ -33,6 +33,16 @@ struct SharedFileManager {
         try FileManager.default.copyItem(at: url, to: destURL)
     }
 
+    /// Create a subfolder inside an optional parent path
+    static func createSubfolder(named name: String, in parent: String = "") throws {
+        var url = documentsURL
+        if !parent.isEmpty {
+            url.appendPathComponent(parent, isDirectory: true)
+        }
+        url.appendPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
     /// List all subfolders at an optional relative path
     static func listFolders(at subpath: String = "") -> [String] {
         let url = subpath.isEmpty


### PR DESCRIPTION
## Summary
- add ability to create new subfolders from the share extension
- refresh folder list after creating the new folder
- expose `createSubfolder` utility on `SharedFileManager`

## Testing
- `swift --version`
- `swift test -list-tests` *(fails: Missing value)*

------
https://chatgpt.com/codex/tasks/task_e_6845f13e40d4833194444378f24f5354