### PR TITLE
Add FileManagerService tests

### DIFF
--- a/NexusFileApp/Services/FileManagerService.swift
+++ b/NexusFileApp/Services/FileManagerService.swift
@@ -24,12 +24,12 @@ class FileManagerService: ObservableObject {
         "Crop Info"
     ]
 
-    init(startingAt url: URL? = nil) {
-        let docs = fileManager
+    init(startingAt url: URL? = nil,
+         documentsURL: URL = FileManager.default
             .urls(for: .documentDirectory, in: .userDomainMask)
-            .first!
-        self.documentsURL = docs
-        self.currentURL = url ?? docs
+            .first!) {
+        self.documentsURL = documentsURL
+        self.currentURL = url ?? documentsURL
 
         ensureDefaultCategories()
         loadItems()
@@ -92,7 +92,7 @@ class FileManagerService: ObservableObject {
     }
 
     func navigate(to item: DirectoryItem) -> FileManagerService {
-        FileManagerService(startingAt: item.id)
+        FileManagerService(startingAt: item.id, documentsURL: documentsURL)
     }
 
     func createFolder(named name: String) {

--- a/NexusFileAppTests/NexusFileAppTests.swift
+++ b/NexusFileAppTests/NexusFileAppTests.swift
@@ -10,8 +10,53 @@ import Testing
 
 struct NexusFileAppTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    private func makeService() throws -> FileManagerService {
+        let fm = FileManager.default
+        let tempRoot = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fm.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        return FileManagerService(startingAt: tempRoot, documentsURL: tempRoot)
+    }
+
+    @Test func createFolder() throws {
+        let service = try makeService()
+        let fm = FileManager.default
+        service.createFolder(named: "Test")
+        let path = service.currentURL.appendingPathComponent("Test").path
+        #expect(fm.fileExists(atPath: path))
+    }
+
+    @Test func importFile() throws {
+        let service = try makeService()
+        let fm = FileManager.default
+        let src = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".txt")
+        try "hello".write(to: src, atomically: true, encoding: .utf8)
+        service.importFile(from: src)
+        let dest = service.currentURL.appendingPathComponent(src.lastPathComponent).path
+        #expect(fm.fileExists(atPath: dest))
+    }
+
+    @Test func rename() throws {
+        let service = try makeService()
+        let fm = FileManager.default
+        let file = service.currentURL.appendingPathComponent("file.txt")
+        try "data".write(to: file, atomically: true, encoding: .utf8)
+        service.loadItems()
+        let item = DirectoryItem(id: file)
+        service.rename(item: item, to: "renamed.txt")
+        let newURL = service.currentURL.appendingPathComponent("renamed.txt")
+        #expect(fm.fileExists(atPath: newURL.path))
+        #expect(!fm.fileExists(atPath: file.path))
+    }
+
+    @Test func delete() throws {
+        let service = try makeService()
+        let fm = FileManager.default
+        let file = service.currentURL.appendingPathComponent("todelete.txt")
+        try "bye".write(to: file, atomically: true, encoding: .utf8)
+        service.loadItems()
+        let item = DirectoryItem(id: file)
+        service.delete(item: item)
+        #expect(!fm.fileExists(atPath: file.path))
     }
 
 }


### PR DESCRIPTION
## Summary
- allow injecting a custom `documentsURL` into `FileManagerService`
- propagate custom URL when navigating to folders
- add new `NexusFileAppTests` covering createFolder, importFile, rename, and delete operations

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6845f3883e808331b080259172309b66