### PR TITLE
Add .gitignore for Xcode and Swift artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# macOS
+.DS_Store
+
+# Xcode user data
+*.xcuserstate
+*.xcuserdata
+
+# Build products
+DerivedData/
+build/
+
+# Swift Package Manager
+.build/
+Packages/
+Package.pins
+Package.resolved
+
+# CocoaPods
+Pods/
+
+# Carthage
+Carthage/Build/
+
+# Fastlane
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output


### PR DESCRIPTION
## Summary
- add root `.gitignore` ignoring Xcode user data, build outputs, and other common Swift files

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6845f52b40ec83319f5458f653a234af