### PR TITLE
Add haptic feedback service

### DIFF
--- a/NexusFileApp/Services/Haptics.swift
+++ b/NexusFileApp/Services/Haptics.swift
@@ -7,4 +7,35 @@
 
 import UIKit
 
-class Haptics { /* as before */ }
+/// Simple wrapper around ``UIFeedbackGenerator`` types used across the app.
+/// Provides one-line static helpers for the common haptic events.
+enum Haptics {
+
+    /// Light impact used for selection like feedback.
+    static func selection() {
+        let generator = UIImpactFeedbackGenerator(style: .light)
+        generator.prepare()
+        generator.impactOccurred()
+    }
+
+    /// Notifies the user of a successful action.
+    static func success() {
+        let generator = UINotificationFeedbackGenerator()
+        generator.prepare()
+        generator.notificationOccurred(.success)
+    }
+
+    /// Warning haptic used for non destructive alerts.
+    static func warning() {
+        let generator = UINotificationFeedbackGenerator()
+        generator.prepare()
+        generator.notificationOccurred(.warning)
+    }
+
+    /// Error haptic for destructive or failed actions.
+    static func error() {
+        let generator = UINotificationFeedbackGenerator()
+        generator.prepare()
+        generator.notificationOccurred(.error)
+    }
+}

--- a/NexusFileApp/Views/FolderView.swift
+++ b/NexusFileApp/Views/FolderView.swift
@@ -73,8 +73,9 @@ struct FolderView: View {
             }
         }
         .sheet(isPresented: $showingNewFolder) {
-            NewFolderSheet(title: "New Folder", placeholder: "Name") {
-                service.createFolder(named: $0)
+            NewFolderSheet(title: "New Folder", placeholder: "Name") { name in
+                service.createFolder(named: name)
+                Haptics.success()
             }
         }
         .fileImporter(isPresented: $showingImporter,
@@ -82,6 +83,7 @@ struct FolderView: View {
                       allowsMultipleSelection: true) { result in
             if case .success(let urls) = result {
                 urls.forEach { service.importFile(from: $0) }
+                Haptics.success()
             }
         }
         .sheet(item: $shareURL) { url in
@@ -107,6 +109,7 @@ struct FolderView: View {
             ) {
                 Label(item.name, systemImage: "folder.fill")
             }
+            .simultaneousGesture(TapGesture().onEnded { Haptics.selection() })
             .contextMenu {
                 Button("Rename") { renameTarget = item }
                 Button("Delete", role: .destructive) {
@@ -123,6 +126,7 @@ struct FolderView: View {
             }
             .contentShape(Rectangle())
             .onTapGesture {
+                Haptics.selection()
                 previewURL = item.id
             }
             .contextMenu {

--- a/NexusFileApp/Views/HomeView.swift
+++ b/NexusFileApp/Views/HomeView.swift
@@ -30,6 +30,7 @@ struct HomeView: View {
                         ) {
                             CategoryCard(name: item.name)
                         }
+                        .simultaneousGesture(TapGesture().onEnded { Haptics.selection() })
                         .contextMenu {
                             Button("Rename") { renameTarget = item }
                             Button("Delete", role: .destructive) {
@@ -57,6 +58,7 @@ struct HomeView: View {
                     placeholder: "Name"
                 ) { name in
                     fm.createFolder(named: name)
+                    Haptics.success()
                 }
             }
             .sheet(item: $renameTarget) { item in


### PR DESCRIPTION
## Summary
- implement Haptics service using UIFeedbackGenerators
- trigger success haptics after creating folders or importing files
- play selection haptics when opening folders and files

## Testing
- `swift --version`
- `swift test --enable-test-discovery` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6845f52b94e08331be9636476d9b9851