### PR TITLE
Fix shared saving and add iCloud sync

### DIFF
--- a/NexusFileApp/NexusFileApp.entitlements
+++ b/NexusFileApp/NexusFileApp.entitlements
@@ -5,6 +5,14 @@
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.leon.NexusFileApp</string>
-	</array>
+</array>
+        <key>com.apple.developer.icloud-container-identifiers</key>
+        <array>
+                <string>iCloud.com.leon.NexusFileApp</string>
+        </array>
+        <key>com.apple.developer.icloud-services</key>
+        <array>
+                <string>CloudDocuments</string>
+        </array>
 </dict>
 </plist>

--- a/NexusFileApp/Services/FileManagerService.swift
+++ b/NexusFileApp/Services/FileManagerService.swift
@@ -25,9 +25,7 @@ class FileManagerService: ObservableObject {
     ]
 
     init(startingAt url: URL? = nil,
-         documentsURL: URL = FileManager.default
-            .urls(for: .documentDirectory, in: .userDomainMask)
-            .first!) {
+         documentsURL: URL = SharedFileManager.documentsURL) {
         self.documentsURL = documentsURL
         self.currentURL = url ?? documentsURL
 
@@ -144,5 +142,37 @@ class FileManagerService: ObservableObject {
 
     func exportAsPDF(item: DirectoryItem) -> URL? {
         try? ExcelPDFExporter.export(at: item.id)
+    }
+
+    private var iCloudDocumentsURL: URL? {
+        FileManager.default.url(forUbiquityContainerIdentifier: nil)?.appendingPathComponent("Documents", isDirectory: true)
+    }
+
+    func backupToICloud() {
+        guard let cloud = iCloudDocumentsURL else { return }
+        copyRecursive(from: documentsURL, to: cloud)
+    }
+
+    func syncFromICloud() {
+        guard let cloud = iCloudDocumentsURL else { return }
+        copyRecursive(from: cloud, to: documentsURL)
+        loadItems()
+    }
+
+    private func copyRecursive(from src: URL, to dest: URL) {
+        var isDir: ObjCBool = false
+        if fileManager.fileExists(atPath: src.path, isDirectory: &isDir), isDir.boolValue {
+            try? fileManager.createDirectory(at: dest, withIntermediateDirectories: true)
+            let contents = (try? fileManager.contentsOfDirectory(at: src, includingPropertiesForKeys: nil, options: [])) ?? []
+            for item in contents {
+                let destItem = dest.appendingPathComponent(item.lastPathComponent)
+                copyRecursive(from: item, to: destItem)
+            }
+        } else {
+            if fileManager.fileExists(atPath: dest.path) {
+                try? fileManager.removeItem(at: dest)
+            }
+            try? fileManager.copyItem(at: src, to: dest)
+        }
     }
 }

--- a/NexusFileApp/Views/HomeView.swift
+++ b/NexusFileApp/Views/HomeView.swift
@@ -45,7 +45,13 @@ struct HomeView: View {
             .navigationTitle("Categories")
             .navigationBarTitleDisplayMode(.large)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItemGroup(placement: .navigationBarTrailing) {
+                    Button { fm.syncFromICloud() } label: {
+                        Image(systemName: "arrow.triangle.2.circlepath")
+                    }
+                    Button { fm.backupToICloud() } label: {
+                        Image(systemName: "icloud.and.arrow.up")
+                    }
                     Button { showingNew = true } label: {
                         Image(systemName: "plus.circle.fill")
                             .font(.system(size: 22))

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ NexusFileApp provides a Files-like interface to organize, import, preview, and s
 * Search and sort by name or date
 * Rename, duplicate, and delete items with context menus and swipe actions
 * Light and Dark mode with custom branding colors
+* Sync files with iCloud and back them up with one tap
 
 ## Screenshots
 
@@ -45,6 +46,7 @@ NexusFileApp provides a Files-like interface to organize, import, preview, and s
 * In a folder view, use the “...” menu to create a folder, import files, or sort items.
 * Long-press or swipe an item for rename, duplicate, or delete options.
 * Tap the share icon to share documents via Mail, WhatsApp, or other apps.
+* Use the cloud buttons on the home screen to sync or back up all files to iCloud.
 
 ## License
 


### PR DESCRIPTION
## Summary
- use the shared container for saved files so imports and the share extension use the same storage
- add backup/sync actions with iCloud in `FileManagerService`
- place Sync and Backup buttons on the Home screen toolbar
- enable iCloud containers in the entitlements
- document iCloud sync in the README

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68468ab4b9fc833187e00e747288de33