### PR TITLE
Fix color extension and add missing views

### DIFF
--- a/NexusFileApp/Utilities/Color+Nexus.swift
+++ b/NexusFileApp/Utilities/Color+Nexus.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 extension Color {
-    static let nexusGreen = Color("NexusGreen")
-    static let nexusBackground = Color("NexusBackground")
+    /// Primary brand color used throughout the app.
+    static var nexusGreen: Color { Color("NexusGreen") }
+
+    /// Background color that adapts to light and dark mode.
+    static var nexusBackground: Color { Color("NexusBackground") }
 }

--- a/NexusFileApp/Views/CategoryCVCard.swift
+++ b/NexusFileApp/Views/CategoryCVCard.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Card view used in collection layouts to represent a category.
+struct CategoryCVCard: View {
+    let name: String
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "folder.fill")
+                .resizable()
+                .scaledToFit()
+                .frame(height: 50)
+                .foregroundColor(.nexusGreen)
+            Text(name)
+                .font(.headline)
+                .foregroundColor(.primary)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, minHeight: 120)
+        .background(
+            LinearGradient(
+                gradient: Gradient(colors: [Color.white, Color.nexusGreen.opacity(0.15)]),
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        )
+        .cornerRadius(16)
+        .shadow(color: Color.black.opacity(0.15), radius: 6, x: 0, y: 3)
+    }
+}
+
+#Preview {
+    CategoryCVCard(name: "Sample")
+}

--- a/NexusFileApp/Views/GeneralSettingsView.swift
+++ b/NexusFileApp/Views/GeneralSettingsView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+/// Simple settings screen for app preferences.
+struct GeneralSettingsView: View {
+    @AppStorage("useICloudSync") private var useICloudSync = true
+    @AppStorage("showHiddenFiles") private var showHiddenFiles = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Toggle("Use iCloud Sync", isOn: $useICloudSync)
+                Toggle("Show Hidden Files", isOn: $showHiddenFiles)
+            }
+            .navigationTitle("Settings")
+        }
+    }
+}
+
+#Preview {
+    GeneralSettingsView()
+}


### PR DESCRIPTION
## Summary
- tweak Color+Nexus to avoid duplicate constant issues
- add GeneralSettingsView with basic toggles
- add CategoryCVCard view used for collection layouts

## Testing
- `swiftc -typecheck NexusFileApp/Utilities/Color+Nexus.swift NexusFileApp/Views/GeneralSettingsView.swift NexusFileApp/Views/CategoryCVCard.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684691247c308331a3ef2fe91acf4e5b