### PR TITLE
Add folder picker for opening files

### DIFF
--- a/NexusFileApp/NexusFileAppApp.swift
+++ b/NexusFileApp/NexusFileAppApp.swift
@@ -30,7 +30,9 @@ struct NexusFileAppApp: App {
                     }
                 }
                 .sheet(item: $importURL) { fileURL in
-                    ShareContentView(url: fileURL)
+                    ImportFileView(fileURL: fileURL) {
+                        importURL = nil
+                    }
                 }
         }
     }

--- a/NexusFileApp/Shared/SharedFileManager.swift
+++ b/NexusFileApp/Shared/SharedFileManager.swift
@@ -5,8 +5,15 @@ final class SharedFileManager {
     private let fileManager = FileManager.default
     private init() {}
 
+    /// Identifier for the shared app group used by the app and the
+    /// share extension so they operate on the same file container.
+    private let appGroupID = "group.com.leon.NexusFileApp"
+
+    /// Base Documents directory inside the shared app group container.
     var documentsURL: URL {
-        fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        fileManager
+            .containerURL(forSecurityApplicationGroupIdentifier: appGroupID)!
+            .appendingPathComponent("Documents", isDirectory: true)
     }
 
     func listFiles(in subpath: String = "") -> [URL] {
@@ -35,5 +42,29 @@ final class SharedFileManager {
             try fileManager.removeItem(at: dest)
         }
         try fileManager.copyItem(at: url, to: dest)
+    }
+
+    /// Create a subfolder inside an optional parent path
+    func createSubfolder(named name: String, in parent: String = "") throws {
+        var url = documentsURL
+        if !parent.isEmpty {
+            url.appendPathComponent(parent, isDirectory: true)
+        }
+        url.appendPathComponent(name, isDirectory: true)
+        try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    /// List subfolders inside an optional relative path
+    func listFolders(at subpath: String = "") -> [String] {
+        let url = subpath.isEmpty ? documentsURL : documentsURL.appendingPathComponent(subpath, isDirectory: true)
+        guard let contents = try? fileManager.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+        return contents
+            .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false }
+            .map { $0.lastPathComponent }
+            .sorted()
     }
 }

--- a/NexusFileApp/Views/FolderPickerView.swift
+++ b/NexusFileApp/Views/FolderPickerView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Displays a navigable list of folders so the user can choose where to
+/// store an imported file.
+struct FolderPickerView: View {
+    /// The path relative to the shared Documents directory.
+    let subpath: String
+    /// Called when the user taps "Save in …" for the current folder.
+    var onSelect: (String) -> Void
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("Folders") {
+                    ForEach(SharedFileManager.shared.listFolders(at: subpath), id: \.
+self) { name in
+                        let nextPath = subpath.isEmpty ? name : "\(subpath)/\(name)"
+                        NavigationLink {
+                            FolderPickerView(subpath: nextPath, onSelect: onSelect)
+                        } label: {
+                            Text(name)
+                        }
+                    }
+                }
+
+                if !subpath.isEmpty {
+                    Section {
+                        Button("Save in \"\(subpath)\"") {
+                            onSelect(subpath)
+                        }
+                    }
+                }
+            }
+            .navigationTitle(subpath.isEmpty ? "Choose Folder" : subpath)
+        }
+    }
+}

--- a/NexusFileApp/Views/ImportFileView.swift
+++ b/NexusFileApp/Views/ImportFileView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+/// View presented when the app is opened with a file from another app.
+/// Allows the user to select a destination folder and file name.
+struct ImportFileView: View {
+    let fileURL: URL
+    var onComplete: () -> Void
+
+    @State private var chosenFolder = ""
+    @State private var fileName = ""
+    @State private var showingNewFolder = false
+    @State private var refreshID = UUID()
+
+    var body: some View {
+        NavigationStack {
+            FolderPickerView(subpath: "") { folder in
+                chosenFolder = folder
+                fileName = fileURL.lastPathComponent
+            }
+            .id(refreshID)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("New Folder") {
+                        showingNewFolder = true
+                    }
+                    .disabled(chosenFolder.isEmpty)
+                }
+            }
+
+            if !chosenFolder.isEmpty {
+                Form {
+                    Section(header: Text("Folder: \(chosenFolder)")) { }
+                    Section(header: Text("Name")) {
+                        TextField(fileURL.lastPathComponent, text: $fileName)
+                    }
+                    Section {
+                        Button("Save File") {
+                            try? SharedFileManager.shared.save(
+                                file: fileURL,
+                                to: chosenFolder,
+                                named: fileName.isEmpty ? fileURL.lastPathComponent : fileName
+                            )
+                            onComplete()
+                        }
+                    }
+                }
+                .navigationTitle("Import File")
+            }
+        }
+        .sheet(isPresented: $showingNewFolder) {
+            NewFolderSheet(title: "New Subfolder", placeholder: "Name") { name in
+                try? SharedFileManager.shared.createSubfolder(named: name, in: chosenFolder)
+                refreshID = UUID()
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ A modern iOS SwiftUI application to manage and share PDF & Excel documents local
 
 NexusFileApp provides a Files-like interface to organize, import, preview, and share work documents in one place.
 
+When a PDF or Excel file is opened from another app (Mail, Files, WhatsApp, etc.) NexusFileApp now displays a folder picker so you can choose exactly where to store the document.
+
 ## Features
 
 * Manage folders and subfolders
-* Import PDF and Excel files via the Files picker
+* Import PDF and Excel files via the Files picker or by opening them from other apps
 * Preview documents with QuickLook
 * Share files using the iOS share sheet
 * Search and sort by name or date


### PR DESCRIPTION
## Summary
- use shared app group storage in `SharedFileManager`
- add utilities to list and create subfolders
- add `FolderPickerView` and `ImportFileView` for importing external files
- open the folder picker when the app receives a file URL
- document the new behaviour in README

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6846945f379c83318804a8bad29df160