### PR TITLE
Fix redeclaration errors and syntax

### DIFF
--- a/NexusFileApp/Views/FolderPickerView.swift
+++ b/NexusFileApp/Views/FolderPickerView.swift
@@ -12,8 +12,10 @@ struct FolderPickerView: View {
         NavigationStack {
             List {
                 Section("Folders") {
-                    ForEach(SharedFileManager.shared.listFolders(at: subpath), id: \.
-self) { name in
+                    ForEach(
+                        SharedFileManager.shared.listFolders(at: subpath),
+                        id: \.self
+                    ) { name in
                         let nextPath = subpath.isEmpty ? name : "\(subpath)/\(name)"
                         NavigationLink {
                             FolderPickerView(subpath: nextPath, onSelect: onSelect)


### PR DESCRIPTION
## Summary
- fix incorrect `ForEach` syntax in `FolderPickerView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6846964c95b883318cb70ae7e5025a5b