### PR TITLE
Fix default category creation and enable deletion

### DIFF
--- a/NexusFileApp/Services/FileManagerService.swift
+++ b/NexusFileApp/Services/FileManagerService.swift
@@ -34,6 +34,12 @@ class FileManagerService: ObservableObject {
     }
 
     private func ensureDefaultCategories() {
+        var isDir: ObjCBool = false
+        if !fileManager.fileExists(atPath: documentsURL.path, isDirectory: &isDir) {
+            try? fileManager.createDirectory(at: documentsURL,
+                                            withIntermediateDirectories: true)
+        }
+
         let migrations = [
             (old: "Calibrations", new: "Calibration Sheets"),
             (old: "Crop Information", new: "Crop Info")
@@ -60,13 +66,19 @@ class FileManagerService: ObservableObject {
             }
         }
 
+        guard
+            let contents = try? fileManager.contentsOfDirectory(
+                at: documentsURL,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            ),
+            !contents.contains(where: { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false })
+        else { return }
+
         for name in defaultCategories {
             let folderURL = documentsURL.appendingPathComponent(name, isDirectory: true)
-            var isDir: ObjCBool = false
-            if !fileManager.fileExists(atPath: folderURL.path, isDirectory: &isDir) {
-                try? fileManager.createDirectory(at: folderURL,
-                                                 withIntermediateDirectories: false)
-            }
+            try? fileManager.createDirectory(at: folderURL,
+                                             withIntermediateDirectories: true)
         }
     }
 
@@ -95,7 +107,7 @@ class FileManagerService: ObservableObject {
 
     func createFolder(named name: String) {
         let newURL = currentURL.appendingPathComponent(name, isDirectory: true)
-        try? fileManager.createDirectory(at: newURL, withIntermediateDirectories: false)
+        try? fileManager.createDirectory(at: newURL, withIntermediateDirectories: true)
         loadItems()
     }
 


### PR DESCRIPTION
## Summary
- ensure the Documents directory exists before reading or creating categories
- only create default categories on first launch
- allow recursive folder creation when adding new folders

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68469aa0abf883318c75a7c98278e522