### PR TITLE
Fix duplicate color extension

### DIFF
--- a/NexusFileApp/Generated/GeneratedAssetSymbols.swift
+++ b/NexusFileApp/Generated/GeneratedAssetSymbols.swift
@@ -1,0 +1,6 @@
+import SwiftUI
+
+extension SwiftUI.Color {
+    static var nexusBackground: SwiftUI.Color { .init("NexusBackground") }
+    static var nexusGreen: SwiftUI.Color { .init("NexusGreen") }
+}

--- a/NexusFileApp/Utilities/Color+Nexus.swift
+++ b/NexusFileApp/Utilities/Color+Nexus.swift
@@ -1,9 +1,0 @@
-import SwiftUI
-
-extension Color {
-    /// Primary brand color used throughout the app.
-    static var nexusGreen: Color { Color("NexusGreen") }
-
-    /// Background color that adapts to light and dark mode.
-    static var nexusBackground: Color { Color("NexusBackground") }
-}


### PR DESCRIPTION
## Summary
- remove the manually defined `Color+Nexus` extension
- add `GeneratedAssetSymbols.swift` with color symbols

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68469d8182d4833189e17a7d534b7126