### PR TITLE
Add success flow on file import

### DIFF
--- a/NexusFileApp/Info.plist
+++ b/NexusFileApp/Info.plist
@@ -24,8 +24,19 @@
 				<string>org.openxmlformats.spreadsheetml.sheet</string>
 			</array>
 		</dict>
-	</array>
-	<key>UIFileSharingEnabled</key>
-	<false/>
+</array>
+        <key>UIFileSharingEnabled</key>
+        <false/>
+        <key>CFBundleURLTypes</key>
+        <array>
+                <dict>
+                        <key>CFBundleURLName</key>
+                        <string>com.leon.NexusFileApp</string>
+                        <key>CFBundleURLSchemes</key>
+                        <array>
+                                <string>nexusfileapp</string>
+                        </array>
+                </dict>
+        </array>
 </dict>
 </plist>

--- a/NexusFileApp/NexusFileAppApp.swift
+++ b/NexusFileApp/NexusFileAppApp.swift
@@ -10,28 +10,37 @@ import SwiftUI
 @main
 struct NexusFileAppApp: App {
     @State private var importURL: URL?
+    @State private var openFileURL: URL?
 
     var body: some Scene {
         WindowGroup {
-            HomeView()
+            HomeView(openFileURL: $openFileURL)
                 .accentColor(.nexusGreen)
                 .background(Color.nexusBackground.ignoresSafeArea())
                 .onOpenURL { url in
-                    guard url.isFileURL else { return }
-
-                    let tmp = FileManager.default.temporaryDirectory
-                        .appendingPathComponent(url.lastPathComponent)
-                    try? FileManager.default.removeItem(at: tmp)
-                    do {
-                        try FileManager.default.copyItem(at: url, to: tmp)
-                        importURL = tmp
-                    } catch {
-                        // Ignore copy failures
+                    if url.isFileURL {
+                        let tmp = FileManager.default.temporaryDirectory
+                            .appendingPathComponent(url.lastPathComponent)
+                        try? FileManager.default.removeItem(at: tmp)
+                        do {
+                            try FileManager.default.copyItem(at: url, to: tmp)
+                            importURL = tmp
+                        } catch {
+                            // Ignore copy failures
+                        }
+                    } else if url.scheme == "nexusfileapp" {
+                        let path = url.path.dropFirst()
+                        if !path.isEmpty {
+                            let dest = SharedFileManager.shared.documentsURL
+                                .appendingPathComponent(String(path))
+                            openFileURL = dest
+                        }
                     }
                 }
                 .sheet(item: $importURL) { fileURL in
-                    ImportFileView(fileURL: fileURL) {
+                    ImportFileView(fileURL: fileURL) { saved in
                         importURL = nil
+                        openFileURL = saved
                     }
                 }
         }

--- a/NexusFileApp/Views/FolderView.swift
+++ b/NexusFileApp/Views/FolderView.swift
@@ -11,6 +11,7 @@ import UniformTypeIdentifiers
 struct FolderView: View {
     @ObservedObject var service: FileManagerService
     let title: String
+    var openFileURL: URL? = nil
 
     @State private var showingNewFolder = false
     @State private var showingImporter = false
@@ -97,7 +98,12 @@ struct FolderView: View {
         .sheet(item: $previewURL) { url in
             FilePreviewView(url: url)
         }
-        .onAppear { service.loadItems() }
+        .onAppear {
+            service.loadItems()
+            if let open = openFileURL {
+                previewURL = open
+            }
+        }
     }
 
     @ViewBuilder

--- a/NexusFileApp/Views/HomeView.swift
+++ b/NexusFileApp/Views/HomeView.swift
@@ -8,9 +8,13 @@
 import SwiftUI
 
 struct HomeView: View {
+    @Binding var openFileURL: URL?
     @StateObject private var fm = FileManagerService()
     @State private var showingNew = false
     @State private var renameTarget: DirectoryItem?
+    @State private var pendingFile: URL?
+    @State private var navigateService: FileManagerService?
+    @State private var showSavedAlert = false
 
     let columns = [
         GridItem(.flexible()),
@@ -73,6 +77,46 @@ struct HomeView: View {
                 }
             }
             .onAppear { fm.loadItems() }
+            .alert("Successfully saved", isPresented: $showSavedAlert) {
+                Button("Open") {
+                    if let file = pendingFile {
+                        let folder = file.deletingLastPathComponent()
+                        navigateService = FileManagerService(startingAt: folder,
+                                                             documentsURL: SharedFileManager.shared.documentsURL)
+                    }
+                }
+                Button("Cancel", role: .cancel) {}
+            }
+            .background(
+                NavigationLink(
+                    destination: destinationView(),
+                    isActive: Binding(
+                        get: { navigateService != nil },
+                        set: { if !$0 { navigateService = nil } }
+                    )
+                ) { EmptyView() }
+                .hidden()
+            )
+            .onChange(of: openFileURL) { url in
+                if let url {
+                    pendingFile = url
+                    showSavedAlert = true
+                    openFileURL = nil
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func destinationView() -> some View {
+        if let service = navigateService {
+            FolderView(
+                service: service,
+                title: service.currentURL.lastPathComponent,
+                openFileURL: pendingFile
+            )
+        } else {
+            EmptyView()
         }
     }
 }

--- a/NexusFileApp/Views/ImportFileView.swift
+++ b/NexusFileApp/Views/ImportFileView.swift
@@ -4,12 +4,14 @@ import SwiftUI
 /// Allows the user to select a destination folder and file name.
 struct ImportFileView: View {
     let fileURL: URL
-    var onComplete: () -> Void
+    var onComplete: (URL) -> Void
 
     @State private var chosenFolder = ""
     @State private var fileName = ""
     @State private var showingNewFolder = false
     @State private var refreshID = UUID()
+    @State private var savedURL: URL?
+    @State private var showSuccess = false
 
     var body: some View {
         NavigationStack {
@@ -35,12 +37,17 @@ struct ImportFileView: View {
                     }
                     Section {
                         Button("Save File") {
+                            let name = fileName.isEmpty ? fileURL.lastPathComponent : fileName
                             try? SharedFileManager.shared.save(
                                 file: fileURL,
                                 to: chosenFolder,
-                                named: fileName.isEmpty ? fileURL.lastPathComponent : fileName
+                                named: name
                             )
-                            onComplete()
+                            let dest = SharedFileManager.shared.documentsURL
+                                .appendingPathComponent(chosenFolder, isDirectory: true)
+                                .appendingPathComponent(name)
+                            savedURL = dest
+                            showSuccess = true
                         }
                     }
                 }
@@ -51,6 +58,15 @@ struct ImportFileView: View {
             NewFolderSheet(title: "New Subfolder", placeholder: "Name") { name in
                 try? SharedFileManager.shared.createSubfolder(named: name, in: chosenFolder)
                 refreshID = UUID()
+            }
+        }
+        .alert("Successfully saved", isPresented: $showSuccess) {
+            Button("OK") {
+                if let dest = savedURL {
+                    onComplete(dest)
+                } else {
+                    onComplete(fileURL)
+                }
             }
         }
     }

--- a/NexusShareExtension/ShareContentView.swift
+++ b/NexusShareExtension/ShareContentView.swift
@@ -9,12 +9,15 @@ import SwiftUI
 
 struct ShareContentView: View {
     let sharedURL: URL
-    var onSave: (String, String) -> Void
+    var onSave: (String, String) -> URL?
+    var onOpen: (URL) -> Void
 
     @State private var chosenFolder = ""
     @State private var fileName = ""
     @State private var showingNewFolder = false
     @State private var refreshID = UUID()
+    @State private var savedURL: URL?
+    @State private var showSuccess = false
 
     var body: some View {
         NavigationStack {
@@ -41,10 +44,13 @@ struct ShareContentView: View {
                     }
                     Section {
                         Button("Stoor Lêer") {
-                            onSave(chosenFolder,
-                                   fileName.isEmpty
-                                     ? sharedURL.lastPathComponent
-                                     : fileName)
+                            if let dest = onSave(
+                                chosenFolder,
+                                fileName.isEmpty ? sharedURL.lastPathComponent : fileName
+                            ) {
+                                savedURL = dest
+                                showSuccess = true
+                            }
                         }
                     }
                 }
@@ -56,6 +62,14 @@ struct ShareContentView: View {
                 try? SharedFileManager.createSubfolder(named: name, in: chosenFolder)
                 refreshID = UUID()
             }
+        }
+        .alert("Successfully saved", isPresented: $showSuccess) {
+            Button("Open") {
+                if let dest = savedURL {
+                    onOpen(dest)
+                }
+            }
+            Button("Done", role: .cancel) {}
         }
     }
 }

--- a/NexusShareExtension/ShareViewController.swift
+++ b/NexusShareExtension/ShareViewController.swift
@@ -52,11 +52,23 @@ class ShareViewController: UIViewController {
     private func presentShareUI() {
         guard let fileURL = sharedURL else { return }
         // Wrap your SwiftUI ShareContentView
-        let content = ShareContentView(sharedURL: fileURL) { folder, name in
-            try? SharedFileManager.save(file: fileURL, to: folder, named: name)
-            self.extensionContext?
-                .completeRequest(returningItems: [], completionHandler: nil)
-        }
+        let content = ShareContentView(
+            sharedURL: fileURL,
+            onSave: { folder, name in
+                try? SharedFileManager.save(file: fileURL, to: folder, named: name)
+                return SharedFileManager.documentsURL
+                    .appendingPathComponent(folder, isDirectory: true)
+                    .appendingPathComponent(name)
+            },
+            onOpen: { saved in
+                let base = SharedFileManager.documentsURL.path + "/"
+                let relative = saved.path.replacingOccurrences(of: base, with: "")
+                if let url = URL(string: "nexusfileapp://\(relative)") {
+                    self.extensionContext?.open(url, completionHandler: nil)
+                }
+                self.extensionContext?.completeRequest(returningItems: [], completionHandler: nil)
+            }
+        )
         let host = UIHostingController(rootView: content)
         addChild(host)
         host.view.frame = view.bounds


### PR DESCRIPTION
## Summary
- add URL scheme so extensions can open the app
- show success alert when importing a file
- open folder containing saved file from HomeView
- preview target file automatically in FolderView
- allow Share extension to alert on save and open NexusFileApp

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6846a4c190088331823ffc556e6823fc